### PR TITLE
Add basic bot modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Gotlockz Bot
+
+This repository contains a simple Discord bot with a collection of helper modules.
+The bot provides a few sample commands for interacting with the OpenAI API and
+retrieving MLB data. The supporting modules offer lightweight wrappers around
+APIs such as Tesseract OCR, the MLB Stats API and Google Sheets.
+
+## Usage
+
+Install the requirements and set the required environment variables, e.g.:
+
+```bash
+pip install -r requirements.txt
+export DISCORD_TOKEN=<your token>
+export OPENAI_API_KEY=<your key>
+```
+
+Run the bot with:
+
+```bash
+python bot.py
+```
+
+The bot currently implements the following commands:
+
+- `/ping` – respond with "Pong!".
+- `/analyze <text>` – send the text to OpenAI and return a short analysis.
+- `/games` – list today's MLB games.
+
+These examples can be expanded by building on the helper modules in
+`gotlockz_bot/`.

--- a/bot.py
+++ b/bot.py
@@ -1,21 +1,30 @@
 # bot.py
 
+import os
+
 import discord
 from discord.ext import commands
-import os
 from dotenv import load_dotenv
+
+from gotlockz_bot import setup_bot
+from gotlockz_bot.utils import setup_logging
 
 load_dotenv()
 TOKEN = os.getenv("DISCORD_TOKEN", "no-token-set")
+
+setup_logging()
 
 intents = discord.Intents.default()
 intents.message_content = True
 
 bot = commands.Bot(command_prefix='/', intents=intents)
+setup_bot(bot)
+
 
 @bot.event
 async def on_ready():
     print(f"Logged in as {bot.user} (ID: {bot.user.id})")
+
 
 if __name__ == "__main__":
     if TOKEN == "no-token-set":

--- a/gotlockz_bot/__init__.py
+++ b/gotlockz_bot/__init__.py
@@ -1,1 +1,3 @@
-# Stub file for __init__.py. Actual implementation will be added later.
+from .discord_commands import setup_bot
+
+__all__ = ["setup_bot"]

--- a/gotlockz_bot/discord_commands.py
+++ b/gotlockz_bot/discord_commands.py
@@ -1,1 +1,35 @@
-# Stub file for discord_commands.py. Actual implementation will be added later.
+from discord.ext import commands
+import asyncio
+from .gpt_analyzer import analyze_text
+from .mlb_client import get_today_games
+
+class BasicCommands(commands.Cog):
+    """Collection of simple bot commands."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.command()
+    async def ping(self, ctx: commands.Context):
+        """Respond with pong."""
+        await ctx.send("Pong!")
+
+    @commands.command()
+    async def analyze(self, ctx: commands.Context, *, text: str):
+        """Analyze text using GPT and return the result."""
+        result = await asyncio.to_thread(analyze_text, text)
+        await ctx.send(result)
+
+    @commands.command()
+    async def games(self, ctx: commands.Context):
+        """Show today's MLB games."""
+        games = await asyncio.to_thread(get_today_games)
+        if games:
+            await ctx.send("\n".join(games))
+        else:
+            await ctx.send("No games found today.")
+
+
+def setup_bot(bot: commands.Bot):
+    """Register the commands with the bot."""
+    bot.add_cog(BasicCommands(bot))

--- a/gotlockz_bot/gpt_analyzer.py
+++ b/gotlockz_bot/gpt_analyzer.py
@@ -1,1 +1,15 @@
-# Stub file for gpt_analyzer.py. Actual implementation will be added later.
+"""Utilities for analyzing text with OpenAI."""
+
+import os
+import openai
+
+
+def analyze_text(text: str) -> str:
+    """Return a short analysis of the given text using the OpenAI API."""
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": text}],
+        max_tokens=50,
+    )
+    return response.choices[0].message["content"].strip()

--- a/gotlockz_bot/linewatch_module.py
+++ b/gotlockz_bot/linewatch_module.py
@@ -1,1 +1,18 @@
-# Stub file for linewatch_module.py. Actual implementation will be added later.
+"""Utilities for watching line movement."""
+
+import asyncio
+from typing import Awaitable, Callable
+
+
+async def watch_line(
+    get_line: Callable[[], Awaitable[float]],
+    threshold: float,
+    callback: Callable[[float], Awaitable[None]],
+):
+    """Poll get_line until the line crosses the threshold."""
+    while True:
+        line = await get_line()
+        if line >= threshold:
+            await callback(line)
+            break
+        await asyncio.sleep(60)

--- a/gotlockz_bot/mlb_client.py
+++ b/gotlockz_bot/mlb_client.py
@@ -1,1 +1,20 @@
-# Stub file for mlb_client.py. Actual implementation will be added later.
+"""Simple MLB API client."""
+
+from datetime import date
+import requests
+
+
+def get_today_games():
+    """Return a list of today's MLB games."""
+    today = date.today().strftime("%Y-%m-%d")
+    url = f"https://statsapi.mlb.com/api/v1/schedule?sportId=1&date={today}"
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    games = []
+    for entry in data.get("dates", []):
+        for game in entry.get("games", []):
+            home = game["teams"]["home"]["team"]["name"]
+            away = game["teams"]["away"]["team"]["name"]
+            games.append(f"{away} @ {home}")
+    return games

--- a/gotlockz_bot/ocr_parser.py
+++ b/gotlockz_bot/ocr_parser.py
@@ -1,1 +1,10 @@
-# Stub file for ocr_parser.py. Actual implementation will be added later.
+"""OCR parsing utilities."""
+
+from PIL import Image
+import pytesseract
+
+
+def parse_image(path: str) -> str:
+    """Extract text from an image file."""
+    img = Image.open(path)
+    return pytesseract.image_to_string(img)

--- a/gotlockz_bot/odds_client.py
+++ b/gotlockz_bot/odds_client.py
@@ -1,1 +1,10 @@
-# Stub file for odds_client.py. Actual implementation will be added later.
+"""HTTP client for fetching odds data."""
+
+import requests
+
+
+def fetch_odds(url: str):
+    """Fetch JSON odds data from the given API URL."""
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.json()

--- a/gotlockz_bot/portfolio_module.py
+++ b/gotlockz_bot/portfolio_module.py
@@ -1,1 +1,15 @@
-# Stub file for portfolio_module.py. Actual implementation will be added later.
+"""Simple portfolio tracking for wagers."""
+
+
+class Portfolio:
+    def __init__(self):
+        self.bets = []
+
+    def add_bet(self, team: str, amount: float, odds: float):
+        self.bets.append({"team": team, "amount": amount, "odds": odds})
+
+    def total_exposure(self) -> float:
+        return sum(b["amount"] for b in self.bets)
+
+    def clear(self):
+        self.bets.clear()

--- a/gotlockz_bot/research_module.py
+++ b/gotlockz_bot/research_module.py
@@ -1,1 +1,13 @@
-# Stub file for research_module.py. Actual implementation will be added later.
+"""Utilities for researching MLB teams."""
+
+import requests
+
+
+def team_info(team: str):
+    """Return basic information about an MLB team."""
+    resp = requests.get("https://statsapi.mlb.com/api/v1/teams?sportId=1", timeout=10)
+    resp.raise_for_status()
+    for t in resp.json().get("teams", []):
+        if team.lower() in t["name"].lower():
+            return t
+    return {}

--- a/gotlockz_bot/sheets_client.py
+++ b/gotlockz_bot/sheets_client.py
@@ -1,1 +1,17 @@
-# Stub file for sheets_client.py. Actual implementation will be added later.
+"""Wrapper around the gspread client."""
+
+import gspread
+from oauth2client.service_account import ServiceAccountCredentials
+
+
+class SheetsClient:
+    def __init__(self, creds_path: str):
+        scope = [
+            "https://spreadsheets.google.com/feeds",
+            "https://www.googleapis.com/auth/drive",
+        ]
+        creds = ServiceAccountCredentials.from_json_keyfile_name(creds_path, scope)
+        self.client = gspread.authorize(creds)
+
+    def get_sheet(self, name: str):
+        return self.client.open(name).sheet1

--- a/gotlockz_bot/utils.py
+++ b/gotlockz_bot/utils.py
@@ -1,1 +1,7 @@
-# Stub file for utils.py. Actual implementation will be added later.
+"""Miscellaneous utility helpers."""
+
+import logging
+
+
+def setup_logging(level=logging.INFO):
+    logging.basicConfig(level=level)

--- a/gotlockz_bot/valuebets_module.py
+++ b/gotlockz_bot/valuebets_module.py
@@ -1,1 +1,7 @@
-# Stub file for valuebets_module.py. Actual implementation will be added later.
+"""Helpers to identify value bets."""
+
+
+def is_value_bet(probability: float, decimal_odds: float) -> bool:
+    """Return True if the bet has positive expected value."""
+    implied_prob = 1 / decimal_odds
+    return probability > implied_prob

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pytest-asyncio
 aiohttp
 git+https://github.com/toddrob99/MLB-StatsAPI.git
 pybaseball
+pillow


### PR DESCRIPTION
## Summary
- add a README with basic instructions
- implement example modules under `gotlockz_bot`
- update the main bot script to load the new commands
- add Pillow to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684230d1196083208eab05746007066d