### PR TITLE
Add analysis support to postpick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+*.pyc

--- a/bot.py
+++ b/bot.py
@@ -45,11 +45,18 @@ async def on_ready():
 )
 @app_commands.describe(
     units="How many units (e.g. 1.0) to wager on this pick",
+    analysis="Write-up to accompany the pick",
     channel="Which channel to post the pick in"
 )
-async def postpick(interaction: discord.Interaction, units: float, channel: discord.TextChannel):
+async def postpick(
+    interaction: discord.Interaction,
+    units: float,
+    analysis: str,
+    channel: discord.TextChannel,
+):
     """
     /postpick handler: confirm the pick and post it into the specified channel.
+    Sends the analysis text and embed together so they appear in one message.
     """
     # Acknowledge immediately (defer) so the user does not see an “application did not respond” error.
     await interaction.response.defer(ephemeral=True)
@@ -61,8 +68,8 @@ async def postpick(interaction: discord.Interaction, units: float, channel: disc
     )
     embed.set_footer(text="Good luck! 🍀")
 
-    # Send that embed to the target channel.
-    await channel.send(embed=embed)
+    # Send both the analysis text and the embed in a single message.
+    await channel.send(content=analysis, embed=embed)
 
     # Finally, send a follow-up to the original user confirming it was posted.
     await interaction.followup.send(

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+import pytest
+import discord
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import bot
+
+class DummyUser:
+    mention = "@tester"
+
+class DummyResponse:
+    def __init__(self):
+        self.deferred = False
+    async def defer(self, ephemeral=True):
+        self.deferred = ephemeral
+
+class DummyFollowup:
+    def __init__(self):
+        self.sent = None
+    async def send(self, content, ephemeral=True):
+        self.sent = (content, ephemeral)
+
+class DummyInteraction:
+    def __init__(self):
+        self.user = DummyUser()
+        self.response = DummyResponse()
+        self.followup = DummyFollowup()
+
+class DummyChannel:
+    def __init__(self):
+        self.content = None
+        self.embed = None
+        self.mention = "#channel"
+    async def send(self, *, content=None, embed=None):
+        self.content = content
+        self.embed = embed
+
+@pytest.mark.asyncio
+async def test_postpick_sends_analysis_and_embed():
+    interaction = DummyInteraction()
+    channel = DummyChannel()
+    await bot.postpick.callback(interaction, 2.5, "Test analysis", channel)
+
+    assert channel.content == "Test analysis"
+    assert isinstance(channel.embed, discord.Embed)
+    assert "2.5" in channel.embed.description
+    assert interaction.followup.sent[0].startswith("✅ Your pick")


### PR DESCRIPTION
## Summary
- allow `/postpick` command to include analysis text
- ensure embed and analysis post as a single message
- ignore common Python cache dirs
- add tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684273af12a88320a0da2c4c9162edc0