### PR TITLE
Refactor bot tasks into separate modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ python bot.py
 
 Slash commands will sync when the bot starts. The `/postpick` command accepts a unit amount and a text channel and posts an embed in that channel while replying ephemerally to the user.
 
+## Code structure
+
+The bot is organized into small modules so each file focuses on a single task:
+
+- `bot.py` – creates the Discord client and runs the application.
+- `commands.py` – defines slash commands such as `/postpick`.
+- `tasks.py` – background tasks like periodic guild count logging.
+
+Keeping functionality split across modules makes it easier to test and extend individual pieces of the bot.
+
 ## Running tests
 
 Run the automated test suite with `pytest`:

--- a/commands.py
+++ b/commands.py
@@ -1,0 +1,33 @@
+import discord
+from discord import app_commands
+
+
+def register_commands(tree: app_commands.CommandTree, guild_id: int):
+    """Register application commands on the provided command tree."""
+
+    @tree.command(
+        name="postpick",
+        description="Register a pick and post it to your chosen channel",
+        guild=discord.Object(id=guild_id),
+    )
+    @app_commands.describe(
+        units="How many units (e.g. 1.0) to wager on this pick",
+        channel="Which channel to post the pick in",
+    )
+    async def postpick(
+        interaction: discord.Interaction, units: float, channel: discord.TextChannel
+    ):
+        """/postpick handler."""
+        await interaction.response.defer(ephemeral=True)
+        embed = discord.Embed(
+            title="\U0001F4E3 New Pick Posted!",
+            description=f"**Units:** {units}\n**Picked by:** {interaction.user.mention}",
+        )
+        embed.set_footer(text="Good luck! \U0001F340")
+        await channel.send(embed=embed)
+        await interaction.followup.send(
+            f"\u2705 Your pick of **{units} units** has been posted in {channel.mention}.",
+            ephemeral=True,
+        )
+
+    return postpick

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,14 @@
+import logging
+from discord.ext import tasks
+
+log = logging.getLogger("gotlockz")
+
+
+def create_log_guild_count_task(bot):
+    """Return a task that logs how many guilds the bot is connected to."""
+
+    @tasks.loop(minutes=30)
+    async def log_guild_count():
+        log.info("Currently connected to %d guild(s)", len(bot.guilds))
+
+    return log_guild_count


### PR DESCRIPTION
## Summary
- split `/postpick` command into `commands.py`
- move background logging loop into `tasks.py`
- update `bot.py` to import new modules
- document code structure in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427876da048320abc63173a9e99922