### PR TITLE
Add AI analysis feature and restore run_bot function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # GotLockz Discord Bot
 
-This repository contains a simple Discord bot that posts picks via a `/postpick` slash command. The bot uses `discord.py` 2.5+ and registers commands to a single guild for faster updates.
+This repository contains a simple Discord bot that posts picks via a `/postpick` slash command and can analyse bet slip images with `/analyze_bet`. The bot uses `discord.py` 2.5+ and registers commands to a single guild for faster updates.
 
 ## Environment variables
 
 - `DISCORD_TOKEN` – your bot's token
 - `GUILD_ID` – ID of the guild where slash commands should be registered
+- `OPENAI_API_KEY` – optional, used to power the `/analyze_bet` command
 
 These need to be configured in your local shell or in Render.com's **Environment Variables** settings.
 You can copy `.env.example` to `.env` and edit it with your own values when running locally:
@@ -30,7 +31,7 @@ python bot.py
 2. Set `DISCORD_TOKEN` and `GUILD_ID` in the service's environment variables.
 3. Render will build the Dockerfile and run `python bot.py` automatically.
 
-Slash commands will sync when the bot starts. The `/postpick` command accepts a unit amount and a text channel and posts an embed in that channel while replying ephemerally to the user.
+Slash commands will sync when the bot starts. The `/postpick` command accepts a unit amount and a text channel and posts an embed in that channel while replying ephemerally to the user. The `/analyze_bet` command lets users upload a bet slip image and returns an AI-generated breakdown when `OPENAI_API_KEY` is configured.
 
 ## Running tests
 

--- a/ai_analysis.py
+++ b/ai_analysis.py
@@ -1,0 +1,34 @@
+import os
+import logging
+import openai
+
+log = logging.getLogger(__name__)
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+
+def generate_analysis(bet_details: dict) -> str:
+    """Generate a short analysis of the bet using OpenAI."""
+    if not openai.api_key:
+        log.warning("OPENAI_API_KEY is not configured; skipping analysis")
+        return "AI analysis unavailable"
+
+    system_msg = (
+        "You are a helpful assistant that analyzes MLB bets. "
+        "Provide a concise recommendation based on the following details."
+    )
+    user_content = "\n".join(f"{k}: {v}" for k, v in bet_details.items())
+
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": system_msg},
+                {"role": "user", "content": user_content},
+            ],
+            max_tokens=150,
+        )
+        return response.choices[0].message["content"].strip()
+    except Exception as exc:  # pragma: no cover - network failure
+        log.error("OpenAI request failed: %s", exc)
+        return "Unable to generate AI analysis."

--- a/bot.py
+++ b/bot.py
@@ -19,6 +19,13 @@ intents = discord.Intents.default()
 bot = commands.Bot(command_prefix="!", intents=intents)
 tree = bot.tree
 
+
+def run_bot() -> None:
+    """Run the Discord bot after validating configuration."""
+    if DISCORD_TOKEN is None or GUILD_ID == 0:
+        raise RuntimeError("DISCORD_TOKEN or GUILD_ID not set in environment")
+    bot.run(DISCORD_TOKEN)
+
 @bot.event
 async def on_ready():
     log.info(f"GotLockz bot logged in as {bot.user} (ID: {bot.user.id})")
@@ -87,8 +94,8 @@ async def analyze_bet(interaction: discord.Interaction, image: discord.Attachmen
         await interaction.followup.send("\u274C Failed to analyze the bet slip. Please make sure the image is clear and try again.", ephemeral=True)
 
 if __name__ == "__main__":
-    if DISCORD_TOKEN is None or GUILD_ID == 0:
-        log.error("DISCORD_TOKEN or GUILD_ID not set in environment!")
-        exit(1)
-
-    bot.run(DISCORD_TOKEN)
+    try:
+        run_bot()
+    except Exception as exc:  # pragma: no cover - runtime failure
+        log.error("Bot failed to start: %s", exc)
+        raise


### PR DESCRIPTION
## Summary
- create `ai_analysis.py` for AI-backed bet breakdowns
- restore `run_bot()` in `bot.py` and use it in `__main__`
- document the new `/analyze_bet` command and `OPENAI_API_KEY` env var in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427a88b2b48320a2eb5a9ca26336ce