### PR TITLE
Update README with OCR prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ You can copy `.env.example` to `.env` and edit it with your own values when runn
 cp .env.example .env
 ```
 
+The OCR functionality in `/analyze_bet` requires the `tesseract-ocr` engine and
+its development libraries. Refer to the Dockerfile for the full list of apt
+packages that need to be installed.
+
 ## Running locally
 
 ```bash


### PR DESCRIPTION
## Summary
- document that tesseract-ocr must be installed for the OCR features
- point users to the Dockerfile for the necessary apt packages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427d6e7fac8320ae582dfddbb41914