### PR TITLE
Add cleanup for analyze_bet temp file

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -92,7 +92,11 @@ async def analyze_bet(interaction: discord.Interaction, image: discord.Attachmen
     except Exception as e:
         log.error(f"Failed to process bet image: {e}")
         await interaction.followup.send("\u274C Failed to analyze the bet slip. Please make sure the image is clear and try again.", ephemeral=True)
-
+    finally:
+        try:
+            os.remove(image_path)
+        except OSError:
+            pass
 if __name__ == "__main__":
     try:
         run_bot()

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5,6 +5,36 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 import discord
 import bot
+import pytest
+import asyncio
+
+
+class DummyResponse:
+    async def defer(self, ephemeral=True):
+        self.ephemeral = ephemeral
+
+
+class DummyFollowup:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, *args, **kwargs):
+        self.sent.append((args, kwargs))
+
+
+class DummyInteraction:
+    def __init__(self):
+        self.response = DummyResponse()
+        self.followup = DummyFollowup()
+
+
+class DummyAttachment:
+    def __init__(self, filename: str):
+        self.filename = filename
+
+    async def save(self, path: str):
+        with open(path, "w") as f:
+            f.write("data")
 
 
 def test_postpick_command_registered():
@@ -14,3 +44,16 @@ def test_postpick_command_registered():
     command = cmds["postpick"]
     param_names = [p.name for p in command.parameters]
     assert param_names == ["units", "channel"]
+
+
+def test_analyze_bet_file_cleanup(monkeypatch):
+    interaction = DummyInteraction()
+    attachment = DummyAttachment("cleanup.txt")
+
+    monkeypatch.setattr(bot, "extract_text_from_image", lambda p: "text")
+    monkeypatch.setattr(bot, "parse_bet_details", lambda t: {})
+    monkeypatch.setattr(bot, "generate_analysis", lambda d: "analysis")
+
+    asyncio.run(bot.analyze_bet.callback(interaction, attachment))
+
+    assert not os.path.exists(f"/tmp/{attachment.filename}")


### PR DESCRIPTION
## Summary
- ensure `/tmp` image is removed after processing in `analyze_bet`
- add unit test covering the file cleanup logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427d6ca250832099f4d4ff22a68d64