### PR TITLE
Fix invalid multiline string in tests

### DIFF
--- a/tests/ai_analysis.py
+++ b/tests/ai_analysis.py
@@ -4,21 +4,13 @@ import os
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
 def generate_analysis(bet_details: dict) -> str:
-    prompt = (
-        f"You're a professional MLB betting analyst. Analyze this bet based on the details:
-"
-        f"Game: {bet_details.get('game')}
-"
-        f"Pick: {bet_details.get('pick')}
-"
-        f"Units: {bet_details.get('units')}
-"
-        f"Date: {bet_details.get('date')} Time: {bet_details.get('time')}
-"
-        f"VIP: {bet_details.get('vip')}
-"
-        "Give a short paragraph of betting insight backed by real recent stats."
-    )
+    prompt = f"""You're a professional MLB betting analyst. Analyze this bet based on the details:
+Game: {bet_details.get('game')}
+Pick: {bet_details.get('pick')}
+Units: {bet_details.get('units')}
+Date: {bet_details.get('date')} Time: {bet_details.get('time')}
+VIP: {bet_details.get('vip')}
+Give a short paragraph of betting insight backed by real recent stats."""
 
     try:
         response = openai.ChatCompletion.create(


### PR DESCRIPTION
## Summary
- fix `prompt` construction in test helper

## Testing
- `pytest -q`
- `python -m py_compile tests/ai_analysis.py`
- import test module via `importlib`

------
https://chatgpt.com/codex/tasks/task_e_68427d6b04108320ab1476b14076c502